### PR TITLE
[reporter] exclude a few consumer metrics 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.4.0
+version=0.4.1
 

--- a/src/main/java/com/airbnb/kafka/KafkaStatsdMetricsReporter.java
+++ b/src/main/java/com/airbnb/kafka/KafkaStatsdMetricsReporter.java
@@ -40,7 +40,7 @@ public class KafkaStatsdMetricsReporter implements KafkaStatsdMetricsReporterMBe
 
   private static final org.slf4j.Logger log = LoggerFactory.getLogger(StatsDReporter.class);
 
-  public static final String DEFAULT_EXCLUDE_REGEX = "(kafka\\.consumer\\.FetchRequestAndResponseMetrics.*)|(.*ReplicaFetcherThread.*)|(kafka\\.server\\.FetcherLagMetrics\\..*)|(kafka\\.log\\.Log\\..*)|(kafka\\.cluster\\.Partition\\..*)";
+  public static final String DEFAULT_EXCLUDE_REGEX = "(kafka\\.server\\.FetcherStats.*)|(kafka\\.consumer\\.ZookeeperConsumerConnector.*)|(kafka\\.consumer\\.FetchRequestAndResponseMetrics.*)|(kafka\\.consumer\\.FetchRequestAndResponseMetrics.*)|(.*ReplicaFetcherThread.*)|(kafka\\.server\\.FetcherLagMetrics\\..*)|(kafka\\.log\\.Log\\..*)|(kafka\\.cluster\\.Partition\\..*)";
 
   private boolean enabled;
   private final AtomicBoolean running = new AtomicBoolean(false);

--- a/src/main/java/com/airbnb/kafka/KafkaStatsdMetricsReporter.java
+++ b/src/main/java/com/airbnb/kafka/KafkaStatsdMetricsReporter.java
@@ -40,7 +40,7 @@ public class KafkaStatsdMetricsReporter implements KafkaStatsdMetricsReporterMBe
 
   private static final org.slf4j.Logger log = LoggerFactory.getLogger(StatsDReporter.class);
 
-  public static final String DEFAULT_EXCLUDE_REGEX = "(kafka\\.server\\.FetcherStats.*)|(kafka\\.consumer\\.ZookeeperConsumerConnector.*)|(kafka\\.consumer\\.FetchRequestAndResponseMetrics.*)|(kafka\\.consumer\\.FetchRequestAndResponseMetrics.*)|(.*ReplicaFetcherThread.*)|(kafka\\.server\\.FetcherLagMetrics\\..*)|(kafka\\.log\\.Log\\..*)|(kafka\\.cluster\\.Partition\\..*)";
+  public static final String DEFAULT_EXCLUDE_REGEX = "(kafka\\.server\\.FetcherStats.*ConsumerFetcherThread.*)|(kafka\\.consumer\\.FetchRequestAndResponseMetrics.*)|(.*ReplicaFetcherThread.*)|(kafka\\.server\\.FetcherLagMetrics\\..*)|(kafka\\.log\\.Log\\..*)|(kafka\\.cluster\\.Partition\\..*)";
 
   private boolean enabled;
   private final AtomicBoolean running = new AtomicBoolean(false);


### PR DESCRIPTION
/cc @alexism @liukai 

Exclude a few consumer metrics with prefix kafka.consumer.FetchRequestAndResponseMetrics, kafka.consumer.ZookeeperConsumerConnector, and kafka.server.FetcherStats.

We think they are not very useful and may generate a huge number of metric data point if consumer keeps restarting and cause datadog to be slow.
