### PR TITLE
fix infinity metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.2
+
+- Convert INFINITY values to 0.
 
 # 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Metrics can be filtered based on the metric name and the metric dimensions (min,
 
 ## Releases
 
+### 0.5.2
+- Convert INFINITY values to 0.
+
 ### 0.5.1
 - Fix metrics change log level
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.5.1
+version=0.5.2
 

--- a/src/main/java/com/airbnb/metrics/KafkaStatsDReporter.java
+++ b/src/main/java/com/airbnb/metrics/KafkaStatsDReporter.java
@@ -49,10 +49,16 @@ public class KafkaStatsDReporter implements Runnable {
     String tag = registry.getTag(metricName);
 
     final Object value = metric.value();
+    Double val = new Double(value.toString());
+
+    if (val == Double.NEGATIVE_INFINITY || val == Double.POSITIVE_INFINITY) {
+      val = 0D;
+    }
+
     if (tag != null) {
-      statsDClient.gauge(metricName, new Double(value.toString()), tag);
+      statsDClient.gauge(metricName, val, tag);
     } else {
-      statsDClient.gauge(metricName, new Double(value.toString()));
+      statsDClient.gauge(metricName, val);
     }
   }
 


### PR DESCRIPTION
Convert `INFINITY` metrics to 0, datadog agent failed to parse `INFINITY` values.

```
017-04-04 04:16:55 UTC | ERROR | dd.dogstatsd | dogstatsd(dogstatsd.py:432) | Error receiving datagram `kafka.producer-metrics.record-size-max:-∞|g|#client-id:omnes.jitneyLoggingProducer`
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/dogstatsd.py", line 420, in start
    aggregator_submit(message)
  File "/opt/datadog-agent/agent/aggregator.py", line 612, in submit_packets
    parsed_packets = self.parse_metric_packet(packet)
  File "/opt/datadog-agent/agent/aggregator.py", line 485, in parse_metric_packet
    raise Exception(u'Metric value must be a number: %s, %s' % (name, raw_value))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1: ordinal not in range(128)
2017-04-04 04:16:55 UTC | ERROR | dd.dogstatsd | dogstatsd(dogstatsd.py:432) | Error receiving datagram 
```