### PR TITLE
remove reference to old package name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Producer:
 ### Configurations
 ```bash
     # declare the reporter if new producer/consumer is used
-    metric.reporters=com.airbnb.kafka.StatsdMetricsReporter
+    metric.reporters=com.airbnb.kafka.kafka09.StatsdMetricsReporter
 
     # declare the reporter if old producer/consumer is used
     kafka.metrics.reporters=com.airbnb.kafka.kafka08.StatsdMetricsReporter


### PR DESCRIPTION
The class `com.airbnb.kafka.StatsdMetricsReporter` no longer exists. As of PR 16 (https://github.com/airbnb/kafka-statsd-metrics2/pull/16) that class was separated into `com.airbnb.kafka.kafka08.StatsdMetricsReporter` and `com.airbnb.kafka.kafka09.StatsdMetricsReporter`.