### PR TITLE
Fix gradle build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
   - TERM=dumb
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
   - ./gradlew check --info

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:0.9.0-M3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 
@@ -52,7 +52,9 @@ shadowJar {
     exclude 'META-INF/*.DSA'
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/maven/*'
-    exclude dependency('org.apache.kafka:kafka_2.10:0.9.0.1')
-    exclude dependency('org.slf4j:slf4j-log4j12')
+    dependencies {
+        exclude dependency('org.apache.kafka:kafka_2.10:0.9.0.1')
+        exclude dependency('org.slf4j:slf4j-log4j12')
+    }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-all.zip


### PR DESCRIPTION
The existing build script uses outdated gradle versions and dependencies, and no longer works when trying to build the project.

The oudated gradle version leads to the following error:
```
* What went wrong:
A problem occurred configuring root project 'kafka-statsd-metrics2'.
> Could not resolve all dependencies for configuration ':classpath'.
   > Could not resolve com.github.jengelman.gradle.plugins:shadow:0.9.0-M3.
     Required by:
         :kafka-statsd-metrics2:0.5.2
      > Could not HEAD 'http://jcenter.bintray.com/com/github/jengelman/gradle/plugins/shadow/0.9.0-M3/shadow-0.9.0-M3.pom'. Received status code 403 from server: Forbidden
```
This is likely due to older gradle versions not using https and recently [JCenter only supports HTTPS](https://jfrog.com/blog/secure-jcenter-with-https/). Updating the gradle version fixes this issue.

The existing `shadow` plugin dependency also leads to the following error:
```
* What went wrong:
A problem occurred evaluating root project 'kafka-statsd-metrics2'.
> com.google.common.util.concurrent.ExecutionError: java.lang.NoClassDefFoundError: com/github/jengelman/gradle/plugins/shadow/ShadowPlugin$ShadowJavaLibrary
```
This is fixed by using a newer version of `shadow`.

Finally, the way to exclude dependencies in the `shadowJar` task has been updated, which caused this error:
```
* What went wrong:
A problem occurred evaluating root project 'kafka-statsd-metrics2'.
> Could not find method dependency() for arguments [org.apache.kafka:kafka_2.10:0.9.0.1] on task ':shadowJar' of type com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar.
```