### PR TITLE
Fix shadowJar exclude dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ repositories {
 
 dependencies {
     compile 'com.indeed:java-dogstatsd-client:2.0.11'
-    compile 'org.apache.kafka:kafka_2.11:0.9.0.1'
-    compile 'org.slf4j:slf4j-log4j12:+'
+    compileOnly 'org.apache.kafka:kafka_2.11:0.9.0.1'
+    compileOnly 'org.slf4j:slf4j-log4j12:+'
 
     testCompile('junit:junit:4.11',
             'org.easymock:easymock:3.2',
@@ -37,6 +37,9 @@ compileJava {
 }
 
 configurations {
+    // Make compileOnly dependencies available in tests
+    testCompile.extendsFrom compileOnly
+
     //manually excludes some unnecessary dependencies
     compile.exclude module: 'zookeeper'
     compile.exclude module: 'zkclient'
@@ -52,9 +55,5 @@ shadowJar {
     exclude 'META-INF/*.DSA'
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/maven/*'
-    dependencies {
-        exclude dependency('org.apache.kafka:kafka_2.10:0.9.0.1')
-        exclude dependency('org.slf4j:slf4j-log4j12')
-    }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.5.2
+version=0.5.3
 


### PR DESCRIPTION
In my attempt to fix gradle builds in #35, I updated the `shadow` plugin version from `0.9.0-M3` to `5.2.0`.
However, according to https://github.com/johnrengelman/shadow/issues/64, there was a change in behavior when excluding dependencies in the `shadowJar` task where transitive dependencies are not excluded.

This PR attempts to fix the issue by using `compileOnly` for dependencies that were previously listed to be excluded in the `shadowJar` task so that we get effectively the same final jar as before.

Comparing against an older fat jar (`kafka-statsd-metrics2-0.4.0-all.jar`):
```bash
3a4
> META-INF/maven/com.indeed/
10,11c11,15
< com/airbnb/kafka/KafkaStatsdMetricsReporter.class
< com/airbnb/kafka/KafkaStatsdMetricsReporterMBean.class
---
> com/airbnb/kafka/kafka08/
> com/airbnb/kafka/kafka08/StatsdMetricsReporter.class
> com/airbnb/kafka/kafka08/StatsdMetricsReporterMBean.class
> com/airbnb/kafka/kafka09/
> com/airbnb/kafka/kafka09/StatsdMetricsReporter.class
14a19
> com/airbnb/metrics/KafkaStatsDReporter.class
18a24
> com/airbnb/metrics/StatsDMetricsRegistry.class
```
The transitive dependencies are no longer included in the jar and most differences are due to the changes made in version `0.5` instead. I compared against `0.4.0` because in `0.5` an [incorrect version of the kafka dependency](https://github.com/airbnb/kafka-statsd-metrics2/blob/e6eade737aef8f72713bc2257b97e87dbf321ff2/build.gradle#L56) was excluded.

Also bumped up the version of this library to `0.5.3` to [match bintray's latest version](https://bintray.com/airbnb/jars/kafka-statsd-metrics2), which seems to be the same as current `0.5.2` version.

Extracting the classes in `0.5.3` and the current version `0.5.2`:
```bash
colordiff <(ls -ltaR ./52classes | awk '{print $1, $2, $3, $4, $5, $9}' | sort) <(ls -ltaR ./53classes | awk '{print $1, $2, $3, $4, $5, $9}' | sort)
11c11
< -rw-r--r-- 1 edmund_mok staff 2043 MetricNameFormatter.class
---
> -rw-r--r-- 1 edmund_mok staff 2039 MetricNameFormatter.class
13d12
< -rw-r--r-- 1 edmund_mok staff 23087 kafka-statsd-metrics2-0.5.2.jar
22,28c21,28
< ./52classes/META-INF:
< ./52classes/com/airbnb/kafka/kafka08:
< ./52classes/com/airbnb/kafka/kafka09:
< ./52classes/com/airbnb/kafka:
< ./52classes/com/airbnb/metrics:
< ./52classes/com/airbnb:
< ./52classes/com:
---
> -rw-r--r--@ 1 edmund_mok staff 23084 kafka-statsd-metrics2-0.5.3.jar
> ./53classes/META-INF:
> ./53classes/com/airbnb/kafka/kafka08:
> ./53classes/com/airbnb/kafka/kafka09:
> ./53classes/com/airbnb/kafka:
> ./53classes/com/airbnb/metrics:
> ./53classes/com/airbnb:
> ./53classes/com:
```
Using file size as a rough estimate of code differences, we can see the only change is in `MetricNameFormatter.class`.
Used a [Java decompiler](http://java-decompiler.github.io/) to compare both versions and got the following diff:
```bash
colordiff 52dc/MetricNameFormatter.java 53dc/MetricNameFormatter.java
24,31c24
<     return (new StringBuilder(128))
<       .append(metricName.getGroup())
<       .append('.')
<       .append(metricName.getType())
<       .append('.')
<       .append(sanitizeName(metricName.getName()))
<       .append(suffix)
<       .toString();
---
>     return (new StringBuilder(128)).append(metricName.getGroup()).append('.').append(metricName.getType()).append('.').append(sanitizeName(metricName.getName())).append(suffix).toString();
```
Which shows there is no functional difference and it is safe to do the version bump to match bintray.

cc: @parasitew 