### PR TITLE
Fix metrics with tags when using kafka09.StatsdMetricsReporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ jdk:
   - openjdk8
 
 script:
-  - ./gradlew check --info
+  - ./gradlew testWithAllSupportedKafkaVersions

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ Metrics can be filtered based on the metric name and the metric dimensions (min,
 
 ## Releases
 
-### 0.5.2
+### 0.5.4
+- Fix metrics with different tags not reported properly
+
+### 0.5.2 / 0.5.3
 - Convert INFINITY values to 0.
 
 ### 0.5.1

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ for (kafkaVersion in kafkaClientVersionsToTest) {
     tasks = ['test']
     startParameter.projectProperties = [kafkaVersion: "${kafkaVersion}", testWithKafkaClient: true]
     group = 'Verification'
-    description = "Runs the unit tests with Kafka core version ${kafkaVersion}"
+    description = "Runs the unit tests with Kafka client version ${kafkaVersion}"
 
     def srcExcludes = [
       "com/airbnb/kafka/kafka08/": ["**/*"],

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 ext {
   defaultKafkaVersion = '0.9.0.1'
   kafkaVersion = project.getProperties().getOrDefault("kafkaVersion", defaultKafkaVersion)
-  kafkaVersionsToTest = ['0.8.2.2', '0.9.0.1', '0.10.2.2'] //, '2.3.1']
+  kafkaVersionsToTest = ['0.8.2.2', '0.9.0.1', '0.10.2.2', '2.3.1']
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ for (kafkaVersion in kafkaVersionsToTest) {
     // See the following issues:
     // 1. https://github.com/gradle/gradle/issues/11301
     // 2. https://github.com/gradle/gradle/issues/12872
-    buildName = project.getName().concat("-kafka_").concat(kafkaVersionUnderscored)
+    buildName = project.getName() + "-kafka_" + kafkaVersionUnderscored
     buildFile = './build.gradle'
     tasks = ['test']
     startParameter.projectProperties = [kafkaVersion: "${kafkaVersion}"]
@@ -115,30 +115,33 @@ for (kafkaVersion in kafkaClientVersionsToTest) {
     // See the following issues:
     // 1. https://github.com/gradle/gradle/issues/11301
     // 2. https://github.com/gradle/gradle/issues/12872
-    buildName = project.getName().concat("-kafka-clients_").concat(kafkaVersionUnderscored)
+    buildName = project.getName() + "-kafka-clients_" + kafkaVersionUnderscored
     buildFile = './build.gradle'
     tasks = ['test']
     startParameter.projectProperties = [kafkaVersion: "${kafkaVersion}", testWithKafkaClient: true]
     group = 'Verification'
     description = "Runs the unit tests with Kafka core version ${kafkaVersion}"
 
-    compileJava {
-      exclude('com/airbnb/kafka/kafka08')
-      exclude('com/airbnb/metrics/ExcludeMetricPredicate.java')
-      exclude('com/airbnb/metrics/MetricNameFormatter.java')
-      exclude('com/airbnb/metrics/Parser.java')
-      exclude('com/airbnb/metrics/ParserForNoTag.java')
-      exclude('com/airbnb/metrics/ParserForTagInMBeanName.java')
-      exclude('com/airbnb/metrics/StatsDReporter.java')
+    def srcExcludes = [
+      "com/airbnb/kafka/kafka08/": ["**/*"],
+      "com/airbnb/metrics/": ["ExcludeMetricPredicate", "MetricNameFormatter", "Parser", "ParserForNoTag", "ParserForTagInMBeanName", "StatsDReporter"]
+    ]
+    def testExcludes = [
+      "com/airbnb/kafka/kafka08/": ["**/*"],
+      "com/airbnb/metrics/": ["DimensionTest", "ExcludeMetricPredicateTest", "MetricNameFormatterTest", "ParserTest", "StatsDReporterTest"]
+    ]
+    def javaExtension = ".java"
+
+    srcExcludes.each { path, filesToExclude ->
+      filesToExclude.each { fileToExclude ->
+        compileJava.exclude(path + fileToExclude + javaExtension)
+      }
     }
 
-    compileTestJava {
-      exclude('com/airbnb/kafka/kafka08')
-      exclude('com/airbnb/metrics/DimensionTest.java')
-      exclude('com/airbnb/metrics/ExcludeMetricPredicateTest.java')
-      exclude('com/airbnb/metrics/MetricNameFormatterTest.java')
-      exclude('com/airbnb/metrics/ParserTest.java')
-      exclude('com/airbnb/metrics/StatsDReporterTest.java')
+    testExcludes.each { path, filesToExclude ->
+      filesToExclude.each { fileToExclude ->
+        compileTestJava.exclude(path + fileToExclude + javaExtension)
+      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,10 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
-    }
+plugins {
+  id 'java'
+  id 'idea'
+  id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
 defaultTasks 'build'
-
-apply plugin: 'java'
-apply plugin: 'idea'
-apply plugin: 'com.github.johnrengelman.shadow'
 
 group = 'com.airbnb'
 description = 'StatsD Support for Kafka Metrics (kafka version: 0.8 and 0.9)'
@@ -26,9 +19,10 @@ dependencies {
     compileOnly 'org.apache.kafka:kafka_2.11:0.9.0.1'
     compileOnly 'org.slf4j:slf4j-log4j12:+'
 
-    testCompile('junit:junit:4.11',
-            'org.easymock:easymock:3.2',
-            "org.mockito:mockito-core:1.+")
+    testCompile 'junit:junit:4.11'
+    testCompile 'org.easymock:easymock:3.2'
+    testCompile 'org.mockito:mockito-inline:3.5.10'
+    testCompile 'com.google.guava:guava:29.0-jre'
 }
 
 compileJava {
@@ -40,7 +34,7 @@ configurations {
     // Make compileOnly dependencies available in tests
     testCompile.extendsFrom compileOnly
 
-    //manually excludes some unnecessary dependencies
+    // manually excludes some unnecessary dependencies
     compile.exclude module: 'zookeeper'
     compile.exclude module: 'zkclient'
     compile.exclude module: 'javax'

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,14 @@ compileJava {
     options.encoding = 'UTF-8'
 }
 
+def excludeFromCompile(Task task, Map<String, List<String>> excludeMap) {
+  excludeMap.each { path, filesToExclude ->
+    filesToExclude.each { fileToExclude ->
+      task.exclude(path + fileToExclude + ".java")
+    }
+  }
+}
+
 if (testWithKafkaClient) {
   def srcExcludes = [
     "com/airbnb/kafka/kafka08/": ["**/*"],
@@ -60,19 +68,9 @@ if (testWithKafkaClient) {
     "com/airbnb/kafka/kafka08/": ["**/*"],
     "com/airbnb/metrics/": ["DimensionTest", "ExcludeMetricPredicateTest", "MetricNameFormatterTest", "ParserTest", "StatsDReporterTest"]
   ]
-  def javaExtension = ".java"
 
-  srcExcludes.each { path, filesToExclude ->
-    filesToExclude.each { fileToExclude ->
-      compileJava.exclude(path + fileToExclude + javaExtension)
-    }
-  }
-
-  testExcludes.each { path, filesToExclude ->
-    filesToExclude.each { fileToExclude ->
-      compileTestJava.exclude(path + fileToExclude + javaExtension)
-    }
-  }
+  excludeFromCompile(compileJava, srcExcludes)
+  excludeFromCompile(compileTestJava, testExcludes)
 }
 
 configurations {
@@ -159,8 +157,6 @@ task testWithAllSupportedKafkaClientVersions {
   description = "Runs the unit tests with all supported Kafka client versions: ${kafkaClientVersionsToTest}"
   dependsOn(testKafkaClientVersionTasks)
 }
-
-testWithAllSupportedKafkaClientVersions.mustRunAfter(testWithAllSupportedKafkaCoreVersions)
 
 task testWithAllSupportedKafkaVersions {
   group = 'Verification'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
   id 'java'
   id 'idea'
   id 'com.github.johnrengelman.shadow' version '5.2.0'
+  id 'com.adarshr.test-logger' version '2.1.0'
 }
 
 defaultTasks 'build'
@@ -17,7 +18,7 @@ repositories {
 ext {
   defaultKafkaVersion = '0.9.0.1'
   kafkaVersion = project.getProperties().getOrDefault("kafkaVersion", defaultKafkaVersion)
-  kafkaVersionsToTest = ['0.8.2.2', '0.9.0.1', '0.10.2.2', '2.3.1']
+  kafkaVersionsToTest = ['0.8.2.2', '0.9.0.1', '0.10.2.2', '1.1.1', '2.3.1']
 }
 
 dependencies {
@@ -61,7 +62,7 @@ def testKafkaVersionTasks = []
 for (kafkaVersion in kafkaVersionsToTest) {
   String kafkaVersionUnderscored = kafkaVersion.replace('.', '_')
   def task = tasks.create(name: "testWithKafkaCore_${kafkaVersionUnderscored}", type: GradleBuild) {
-    // Changing buildName is a workaround for a Gradle issue when trying to run
+    // Changing `buildName` is a workaround for a Gradle issue when trying to run
     // the aggregate task `testWithAllSupportedKafkaVersions`.
     // See the following issues:
     // 1. https://github.com/gradle/gradle/issues/11301
@@ -79,6 +80,10 @@ for (kafkaVersion in kafkaVersionsToTest) {
   }
 
   testKafkaVersionTasks.add(task)
+}
+
+test.doFirst {
+  println "Running tests with Kafka version ${kafkaVersion}"
 }
 
 task testWithAllSupportedKafkaVersions {

--- a/build.gradle
+++ b/build.gradle
@@ -19,14 +19,26 @@ ext {
   defaultKafkaVersion = '0.9.0.1'
   kafkaVersion = project.getProperties().getOrDefault("kafkaVersion", defaultKafkaVersion)
   kafkaVersionsToTest = ['0.8.2.2', '0.9.0.1', '0.10.2.2', '1.1.1', '2.3.1']
+
+  testWithKafkaClient = project.getProperties().getOrDefault("testWithKafkaClient", false)
+  kafkaClientVersionsToTest = ['0.9.0.1', '0.10.2.2', '1.1.1', '2.3.1']
 }
 
 dependencies {
     compile 'com.indeed:java-dogstatsd-client:2.0.11'
-    compileOnly "org.apache.kafka:kafka_2.11:${defaultKafkaVersion}"
+
+    if (testWithKafkaClient) {
+      compileOnly "org.apache.kafka:kafka-clients:${kafkaVersion}"
+    } else {
+      compileOnly "org.apache.kafka:kafka_2.11:${defaultKafkaVersion}"
+    }
     compileOnly 'org.slf4j:slf4j-log4j12:+'
 
-    testCompile "org.apache.kafka:kafka_2.11:${kafkaVersion}"
+    if (testWithKafkaClient) {
+      testCompile "org.apache.kafka:kafka-clients:${kafkaVersion}"
+    } else {
+      testCompile "org.apache.kafka:kafka_2.11:${kafkaVersion}"
+    }
     testCompile 'org.slf4j:slf4j-log4j12:+'
     testCompile 'junit:junit:4.11'
     testCompile 'org.easymock:easymock:3.2'
@@ -84,10 +96,69 @@ for (kafkaVersion in kafkaVersionsToTest) {
 
 test.doFirst {
   println "Running tests with Kafka version ${kafkaVersion}"
+  println "Testing with Kafka clients: ${testWithKafkaClient}"
 }
+
+task testWithAllSupportedKafkaCoreVersions {
+  group = 'Verification'
+  description = "Runs the unit tests with all supported Kafka core versions: ${kafkaVersionsToTest}"
+  dependsOn(testKafkaVersionTasks)
+}
+
+def testKafkaClientVersionTasks = []
+
+for (kafkaVersion in kafkaClientVersionsToTest) {
+  String kafkaVersionUnderscored = kafkaVersion.replace('.', '_')
+  def task = tasks.create(name: "testWithKafkaClient_${kafkaVersionUnderscored}", type: GradleBuild) {
+    // Changing `buildName` is a workaround for a Gradle issue when trying to run
+    // the aggregate task `testWithAllSupportedKafkaVersions`.
+    // See the following issues:
+    // 1. https://github.com/gradle/gradle/issues/11301
+    // 2. https://github.com/gradle/gradle/issues/12872
+    buildName = project.getName().concat("-kafka-clients_").concat(kafkaVersionUnderscored)
+    buildFile = './build.gradle'
+    tasks = ['test']
+    startParameter.projectProperties = [kafkaVersion: "${kafkaVersion}", testWithKafkaClient: true]
+    group = 'Verification'
+    description = "Runs the unit tests with Kafka core version ${kafkaVersion}"
+
+    compileJava {
+      exclude('com/airbnb/kafka/kafka08')
+      exclude('com/airbnb/metrics/ExcludeMetricPredicate.java')
+      exclude('com/airbnb/metrics/MetricNameFormatter.java')
+      exclude('com/airbnb/metrics/Parser.java')
+      exclude('com/airbnb/metrics/ParserForNoTag.java')
+      exclude('com/airbnb/metrics/ParserForTagInMBeanName.java')
+      exclude('com/airbnb/metrics/StatsDReporter.java')
+    }
+
+    compileTestJava {
+      exclude('com/airbnb/kafka/kafka08')
+      exclude('com/airbnb/metrics/DimensionTest.java')
+      exclude('com/airbnb/metrics/ExcludeMetricPredicateTest.java')
+      exclude('com/airbnb/metrics/MetricNameFormatterTest.java')
+      exclude('com/airbnb/metrics/ParserTest.java')
+      exclude('com/airbnb/metrics/StatsDReporterTest.java')
+    }
+  }
+
+  if (!testKafkaClientVersionTasks.isEmpty()) {
+    task.mustRunAfter(testKafkaClientVersionTasks.last())
+  }
+
+  testKafkaClientVersionTasks.add(task)
+}
+
+task testWithAllSupportedKafkaClientVersions {
+  group = 'Verification'
+  description = "Runs the unit tests with all supported Kafka client versions: ${kafkaClientVersionsToTest}"
+  dependsOn(testKafkaClientVersionTasks)
+}
+
+testWithAllSupportedKafkaClientVersions.mustRunAfter(testWithAllSupportedKafkaCoreVersions)
 
 task testWithAllSupportedKafkaVersions {
   group = 'Verification'
-  description = "Runs the unit tests with all supported Kafka versions: ${kafkaVersionsToTest}"
-  dependsOn(testKafkaVersionTasks)
+  description = "Runs the unit tests with all supported Kafka core and client versions: ${kafkaVersionsToTest}"
+  dependsOn(testWithAllSupportedKafkaCoreVersions, testWithAllSupportedKafkaClientVersions)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,11 +14,19 @@ repositories {
     maven { url "http://dl.bintray.com/airbnb/jars" }
 }
 
+ext {
+  defaultKafkaVersion = '0.9.0.1'
+  kafkaVersion = project.getProperties().getOrDefault("kafkaVersion", defaultKafkaVersion)
+  kafkaVersionsToTest = ['0.8.2.2', '0.9.0.1', '0.10.2.2'] //, '2.3.1']
+}
+
 dependencies {
     compile 'com.indeed:java-dogstatsd-client:2.0.11'
-    compileOnly 'org.apache.kafka:kafka_2.11:0.9.0.1'
+    compileOnly "org.apache.kafka:kafka_2.11:${defaultKafkaVersion}"
     compileOnly 'org.slf4j:slf4j-log4j12:+'
 
+    testCompile "org.apache.kafka:kafka_2.11:${kafkaVersion}"
+    testCompile 'org.slf4j:slf4j-log4j12:+'
     testCompile 'junit:junit:4.11'
     testCompile 'org.easymock:easymock:3.2'
     testCompile 'org.mockito:mockito-inline:3.5.10'
@@ -31,9 +39,6 @@ compileJava {
 }
 
 configurations {
-    // Make compileOnly dependencies available in tests
-    testCompile.extendsFrom compileOnly
-
     // manually excludes some unnecessary dependencies
     compile.exclude module: 'zookeeper'
     compile.exclude module: 'zkclient'
@@ -51,3 +56,33 @@ shadowJar {
     exclude 'META-INF/maven/*'
 }
 
+def testKafkaVersionTasks = []
+
+for (kafkaVersion in kafkaVersionsToTest) {
+  String kafkaVersionUnderscored = kafkaVersion.replace('.', '_')
+  def task = tasks.create(name: "testWithKafkaCore_${kafkaVersionUnderscored}", type: GradleBuild) {
+    // Changing buildName is a workaround for a Gradle issue when trying to run
+    // the aggregate task `testWithAllSupportedKafkaVersions`.
+    // See the following issues:
+    // 1. https://github.com/gradle/gradle/issues/11301
+    // 2. https://github.com/gradle/gradle/issues/12872
+    buildName = project.getName().concat("-kafka_").concat(kafkaVersionUnderscored)
+    buildFile = './build.gradle'
+    tasks = ['test']
+    startParameter.projectProperties = [kafkaVersion: "${kafkaVersion}"]
+    group = 'Verification'
+    description = "Runs the unit tests with Kafka core version ${kafkaVersion}"
+  }
+
+  if (!testKafkaVersionTasks.isEmpty()) {
+    task.mustRunAfter(testKafkaVersionTasks.last())
+  }
+
+  testKafkaVersionTasks.add(task)
+}
+
+task testWithAllSupportedKafkaVersions {
+  group = 'Verification'
+  description = "Runs the unit tests with all supported Kafka versions: ${kafkaVersionsToTest}"
+  dependsOn(testKafkaVersionTasks)
+}

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,30 @@ compileJava {
     options.encoding = 'UTF-8'
 }
 
+if (testWithKafkaClient) {
+  def srcExcludes = [
+    "com/airbnb/kafka/kafka08/": ["**/*"],
+    "com/airbnb/metrics/": ["ExcludeMetricPredicate", "MetricNameFormatter", "Parser", "ParserForNoTag", "ParserForTagInMBeanName", "StatsDReporter"]
+  ]
+  def testExcludes = [
+    "com/airbnb/kafka/kafka08/": ["**/*"],
+    "com/airbnb/metrics/": ["DimensionTest", "ExcludeMetricPredicateTest", "MetricNameFormatterTest", "ParserTest", "StatsDReporterTest"]
+  ]
+  def javaExtension = ".java"
+
+  srcExcludes.each { path, filesToExclude ->
+    filesToExclude.each { fileToExclude ->
+      compileJava.exclude(path + fileToExclude + javaExtension)
+    }
+  }
+
+  testExcludes.each { path, filesToExclude ->
+    filesToExclude.each { fileToExclude ->
+      compileTestJava.exclude(path + fileToExclude + javaExtension)
+    }
+  }
+}
+
 configurations {
     // manually excludes some unnecessary dependencies
     compile.exclude module: 'zookeeper'
@@ -121,28 +145,6 @@ for (kafkaVersion in kafkaClientVersionsToTest) {
     startParameter.projectProperties = [kafkaVersion: "${kafkaVersion}", testWithKafkaClient: true]
     group = 'Verification'
     description = "Runs the unit tests with Kafka client version ${kafkaVersion}"
-
-    def srcExcludes = [
-      "com/airbnb/kafka/kafka08/": ["**/*"],
-      "com/airbnb/metrics/": ["ExcludeMetricPredicate", "MetricNameFormatter", "Parser", "ParserForNoTag", "ParserForTagInMBeanName", "StatsDReporter"]
-    ]
-    def testExcludes = [
-      "com/airbnb/kafka/kafka08/": ["**/*"],
-      "com/airbnb/metrics/": ["DimensionTest", "ExcludeMetricPredicateTest", "MetricNameFormatterTest", "ParserTest", "StatsDReporterTest"]
-    ]
-    def javaExtension = ".java"
-
-    srcExcludes.each { path, filesToExclude ->
-      filesToExclude.each { fileToExclude ->
-        compileJava.exclude(path + fileToExclude + javaExtension)
-      }
-    }
-
-    testExcludes.each { path, filesToExclude ->
-      filesToExclude.each { fileToExclude ->
-        compileTestJava.exclude(path + fileToExclude + javaExtension)
-      }
-    }
   }
 
   if (!testKafkaClientVersionTasks.isEmpty()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.5.3
+version=0.5.4
 

--- a/src/main/java/com/airbnb/kafka/kafka09/StatsdMetricsReporter.java
+++ b/src/main/java/com/airbnb/kafka/kafka09/StatsdMetricsReporter.java
@@ -20,7 +20,6 @@ import com.airbnb.metrics.Dimension;
 import com.airbnb.metrics.KafkaStatsDReporter;
 import com.airbnb.metrics.MetricInfo;
 import com.airbnb.metrics.StatsDMetricsRegistry;
-import com.airbnb.metrics.StatsDReporter;
 
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -38,7 +37,7 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.slf4j.LoggerFactory;
 
 public class StatsdMetricsReporter implements MetricsReporter {
-  private static final org.slf4j.Logger log = LoggerFactory.getLogger(StatsDReporter.class);
+  private static final org.slf4j.Logger log = LoggerFactory.getLogger(StatsdMetricsReporter.class);
 
   public static final String REPORTER_NAME = "kafka-statsd-metrics-0.5";
 

--- a/src/main/java/com/airbnb/kafka/kafka09/StatsdMetricsReporter.java
+++ b/src/main/java/com/airbnb/kafka/kafka09/StatsdMetricsReporter.java
@@ -18,6 +18,7 @@ package com.airbnb.kafka.kafka09;
 
 import com.airbnb.metrics.Dimension;
 import com.airbnb.metrics.KafkaStatsDReporter;
+import com.airbnb.metrics.MetricInfo;
 import com.airbnb.metrics.StatsDMetricsRegistry;
 import com.airbnb.metrics.StatsDReporter;
 
@@ -60,8 +61,9 @@ public class StatsdMetricsReporter implements MetricsReporter {
   private EnumSet<Dimension> metricDimensions;
   private StatsDClient statsd;
   private Map<String, KafkaMetric> kafkaMetrics;
-  private StatsDMetricsRegistry registry;
-  private KafkaStatsDReporter underlying = null;
+
+  StatsDMetricsRegistry registry;
+  KafkaStatsDReporter underlying = null;
 
   public boolean isRunning() {
     return running.get();
@@ -103,15 +105,13 @@ public class StatsdMetricsReporter implements MetricsReporter {
       strBuilder.deleteCharAt(strBuilder.length() - 1);
     }
 
-    registry.register(name, metric, strBuilder.toString());
+    registry.register(metric.metricName(), new MetricInfo(metric, name, strBuilder.toString()));
     log.debug("metrics name: {}", name);
   }
 
   @Override
   public void metricRemoval(KafkaMetric metric) {
-    String name = getMetricName(metric);
-
-    registry.unregister(name);
+    registry.unregister(metric.metricName());
   }
 
   @Override
@@ -155,7 +155,7 @@ public class StatsdMetricsReporter implements MetricsReporter {
     }
   }
 
-  private StatsDClient createStatsd() {
+  StatsDClient createStatsd() {
     try {
       return new NonBlockingStatsDClient(prefix, host, port);
     } catch (StatsDClientException ex) {

--- a/src/main/java/com/airbnb/metrics/MetricInfo.java
+++ b/src/main/java/com/airbnb/metrics/MetricInfo.java
@@ -1,0 +1,27 @@
+package com.airbnb.metrics;
+
+import org.apache.kafka.common.Metric;
+
+public class MetricInfo {
+  private final Metric metric;
+  private final String name;
+  private final String tags;
+
+  public MetricInfo(Metric metric, String name, String tags) {
+    this.metric = metric;
+    this.name = name;
+    this.tags = tags;
+  }
+
+  public Metric getMetric() {
+    return metric;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getTags() {
+    return tags;
+  }
+}

--- a/src/main/java/com/airbnb/metrics/StatsDMetricsRegistry.java
+++ b/src/main/java/com/airbnb/metrics/StatsDMetricsRegistry.java
@@ -1,44 +1,27 @@
 package com.airbnb.metrics;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 
 public class StatsDMetricsRegistry {
-  private final Map<String, Metric> metrics;
-  private final Map<String, String> tags;
+  private final Map<MetricName, MetricInfo> metrics;
 
   public StatsDMetricsRegistry() {
-    metrics= new HashMap<String, Metric>();
-    tags = new HashMap<String, String>();
+    metrics = new HashMap<>();
   }
 
-  public void register(
-    String metricName,
-    Metric metric,
-    String tag
-  ) {
-    metrics.put(metricName, metric);
-    tags.put(metricName, tag);
+  public void register(MetricName metricName, MetricInfo metricInfo) {
+    metrics.put(metricName, metricInfo);
   }
 
-  public void unregister(String metricName) {
+  public void unregister(MetricName metricName) {
     metrics.remove(metricName);
-    tags.remove(metricName);
   }
 
-  public List<String> getMetricsName() {
-    return new ArrayList<String>(metrics.keySet());
-  }
-
-  public Metric getMetric(String metricName) {
-    return metrics.get(metricName);
-  }
-
-  public String getTag(String metricName) {
-    return tags.get(metricName);
+  public Collection<MetricInfo> getAllMetricInfo() {
+      return metrics.values();
   }
 }

--- a/src/test/java/com/airbnb/kafka/kafka09/StatsdMetricsReporterTest.java
+++ b/src/test/java/com/airbnb/kafka/kafka09/StatsdMetricsReporterTest.java
@@ -1,17 +1,37 @@
 package com.airbnb.kafka.kafka09;
 
+import com.airbnb.metrics.MetricInfo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import java.util.stream.Collectors;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class StatsdMetricsReporterTest {
+  private final String TEST_METRIC_NAME = "test-metric";
+  private final String TEST_METRIC_GROUP = "test-group";
+  private final String TEST_METRIC_DESCRIPTION = "This is a test metric.";
+
   private Map<String, String> configs;
 
   @Before
@@ -41,5 +61,34 @@ public class StatsdMetricsReporterTest {
     reporter.configure(configs);
     reporter.init(new ArrayList<KafkaMetric>());
     assertFalse("reporter should NOT be running once #init has been invoked", reporter.isRunning());
+  }
+
+  @Test
+  public void testMetricsReporter_sameMetricNamesWithDifferentTags() {
+    StatsdMetricsReporter reporter = spy(new StatsdMetricsReporter());
+    reporter.configure(ImmutableMap.of(StatsdMetricsReporter.STATSD_REPORTER_ENABLED, "true"));
+    StatsDClient mockStatsDClient = mock(NonBlockingStatsDClient.class);
+    when(reporter.createStatsd()).thenReturn(mockStatsDClient);
+
+    KafkaMetric testMetricWithTag = generateMockKafkaMetric(TEST_METRIC_NAME, TEST_METRIC_GROUP, TEST_METRIC_DESCRIPTION, ImmutableMap.of("test-key", "test-value"));
+    reporter.init(ImmutableList.of(testMetricWithTag));
+    Assert.assertEquals(ImmutableSet.of(testMetricWithTag), getAllKafkaMetricsHelper(reporter));
+
+    KafkaMetric otherTestMetricWithTag = generateMockKafkaMetric(TEST_METRIC_NAME, TEST_METRIC_GROUP, TEST_METRIC_DESCRIPTION, ImmutableMap.of("another-test-key", "another-test-value"));
+    reporter.metricChange(otherTestMetricWithTag);
+    Assert.assertEquals(ImmutableSet.of(testMetricWithTag, otherTestMetricWithTag), getAllKafkaMetricsHelper(reporter));
+
+    reporter.underlying.run();
+    reporter.registry.getAllMetricInfo().forEach(info -> verify(mockStatsDClient, atLeastOnce()).gauge(info.getName(), info.getMetric().value(), info.getTags()));
+  }
+
+  private KafkaMetric generateMockKafkaMetric(String name, String group, String description, Map<String, String> tags) {
+    KafkaMetric mockMetric = mock(KafkaMetric.class);
+    when(mockMetric.metricName()).thenReturn(new MetricName(name, group, description, tags));
+    return mockMetric;
+  }
+
+  private static Collection<Metric> getAllKafkaMetricsHelper(StatsdMetricsReporter reporter) {
+    return reporter.registry.getAllMetricInfo().stream().map(MetricInfo::getMetric).collect(Collectors.toSet());
   }
 }

--- a/src/test/java/com/airbnb/metrics/KafkaStatsDReporterTest.java
+++ b/src/test/java/com/airbnb/metrics/KafkaStatsDReporterTest.java
@@ -2,6 +2,7 @@ package com.airbnb.metrics;
 
 import com.timgroup.statsd.StatsDClient;
 import com.yammer.metrics.core.Clock;
+import java.util.HashMap;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.junit.Before;
@@ -49,11 +50,17 @@ public class KafkaStatsDReporterTest {
     Metric metric = new Metric() {
       @Override
       public MetricName metricName() {
-        return new MetricName("test-metric", "group");
+        return new MetricName("test-metric", "group", "", new HashMap<>());
       }
 
       @Override
       public double value() {
+        return value;
+      }
+
+      // This is a new method added to the `Metric` interface from Kafka v1.0.0,
+      // which we need for tests on later Kafka versions to pass.
+      public Object metricValue() {
         return value;
       }
     };

--- a/src/test/java/com/airbnb/metrics/KafkaStatsDReporterTest.java
+++ b/src/test/java/com/airbnb/metrics/KafkaStatsDReporterTest.java
@@ -1,7 +1,6 @@
 package com.airbnb.metrics;
 
 import com.timgroup.statsd.StatsDClient;
-import com.yammer.metrics.core.Clock;
 import java.util.HashMap;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -14,8 +13,6 @@ import org.mockito.MockitoAnnotations;
 import static org.mockito.Mockito.verify;
 
 public class KafkaStatsDReporterTest {
-  @Mock
-  private Clock clock;
   @Mock
   private StatsDClient statsD;
   private KafkaStatsDReporter reporter;

--- a/src/test/java/com/airbnb/metrics/KafkaStatsDReporterTest.java
+++ b/src/test/java/com/airbnb/metrics/KafkaStatsDReporterTest.java
@@ -31,12 +31,12 @@ public class KafkaStatsDReporterTest {
   }
 
   protected void addMetricAndRunReporter(
-      String metricName,
-      Metric metric,
-      String tag
+    Metric metric,
+    String metricName,
+    String tag
   ) throws Exception {
     try {
-      registry.register(metricName, metric, tag);
+      registry.register(metric.metricName(), new MetricInfo(metric, metricName, tag));
       reporter.run();
     } finally {
       reporter.shutdown();
@@ -58,7 +58,7 @@ public class KafkaStatsDReporterTest {
       }
     };
 
-    addMetricAndRunReporter("foo", metric, "bar");
+    addMetricAndRunReporter(metric, "foo", "bar");
     verify(statsD).gauge(Matchers.eq("foo"), Matchers.eq(value), Matchers.eq("bar"));
   }
 }


### PR DESCRIPTION
Currently the `StatsDMetricsRegistry` class uses a `Map` to store the list of all metrics to be reported, using the metric name as key. Different metric objects can have the same metric name but different tags, so the current registry will cause metrics with same name but different tags to overwrite one another in the `Map`, and results in some metrics not being reported.

Modified `StatsDMetricsRegistry` to use `MetricName` as the key instead, which takes into account these tags.

I have also modified Gradle file to generate several test tasks that use specific versions of `kafka-core` and `kafka-clients` dependencies during compilation and testing so that we can test on different Kafka versions. 

cc @parasitew 
